### PR TITLE
Fix tip calculation in example `sendBackrunBundle.ts`

### DIFF
--- a/src/examples/sendBackrunBundle.ts
+++ b/src/examples/sendBackrunBundle.ts
@@ -14,7 +14,7 @@ const NUM_TARGET_BLOCKS = 3
  */
 const sendTestBackrunBundle = async (provider: JsonRpcProvider, pendingTx: IPendingTransaction, mevshare: MevShareClient, targetBlock: number) => {
     // send bundle w/ (basefee + 100)gwei gas fee
-    const {tx, wallet} = await setupTxExample(provider, BigInt(1e9) * BigInt(1e3), "im backrunniiiiing")
+    const {tx, wallet} = await setupTxExample(provider, BigInt(1e8) * BigInt(1e3), "im backrunniiiiing")
     const backrunTx = {
         ...tx,
         nonce: tx.nonce ? tx.nonce + 1 : undefined,


### PR DESCRIPTION
The tip calculation does not track with the comment. `BigInt(1e9) * BigInt(1e3)` is 1000 Gwei tip, not 100 Gwei tip. Either we want to give the proposer 1000 Gwei, in which case we should update the comment, or we want to give 100 in which case the code is wrong and has been fixed by this PR.