### PR TITLE
Address link issue within interfaces

### DIFF
--- a/src/api/interfaces.ts
+++ b/src/api/interfaces.ts
@@ -128,7 +128,7 @@ export interface BundleParams {
     privacy?: {
         /** Data fields from bundle transactions to be shared with searchers on MEV-Share. */
         hints?: HintPreferences,
-        /** Builders that are allowed to receive this bundle. See [mev-share spec](https://github.com/flashbots/mev-share/blob/main/builders/registration.json) for supported builders. */
+        /** Builders that are allowed to receive this bundle. See [dowg](https://github.com/flashbots/dowg/blob/main/builder-registrations.json) for supported builders. */
         builders?: Array<string>,
     },
     metadata?: {


### PR DESCRIPTION
The link to the mev-share spec for the builder registration is dead. I'm guessing it needs to point to the `dowg` registration repo.