### PR TITLE
fix: preserve nested bundle key in mungers

### DIFF
--- a/src/api/mungers.ts
+++ b/src/api/mungers.ts
@@ -56,7 +56,9 @@ export function mungePrivateTxParams(signedTx: string, options?: TransactionOpti
 export function mungeBundleParams(params: BundleParams) {
     type AnyBundleItem = {hash?: string, tx?: string, bundle?: any, canRevert?: boolean}
     // recursively munge nested bundle params
-    const mungedBundle: any[] = params.body.map((i: AnyBundleItem) => i.bundle ? mungeBundleParams(i.bundle) : i)
+    const mungedBundle: any[] = params.body.map((i: AnyBundleItem) =>
+        i.bundle ? { bundle: mungeBundleParams(i.bundle) } : i
+    )
     return {
         ...params,
         body: mungedBundle,


### PR DESCRIPTION
When encountering nested bundles the mev-share-client includes its properties directly in the outer bundle body causing the bundle to be incorrectly formatted.

This fixes the issue by including the `bundle` key when nesting another bundle.

Fixes: #51 